### PR TITLE
Allow setting values to booleans

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,9 +2,5 @@ preset: laravel
 
 risky: false
 
-enabled:
-  - phpdoc_order
-  - phpdoc_separation
-
 disabled:
     - not_operator_with_successor_space

--- a/src/Env.php
+++ b/src/Env.php
@@ -58,8 +58,8 @@ class Env
      * Set the value of the given key to the value supplied.
      *
      * @param string $key
-     * @param string $value
-     * @param bool   $linebreak
+     * @param string|bool|int $value
+     * @param bool $linebreak
      *
      * @return \Sven\FlexEnv\Env
      */
@@ -67,7 +67,11 @@ class Env
     {
         $oldValue = $this->get($key);
 
-        if (!preg_match('/\d/', $value) || preg_match('/=/', $value)) {
+        if (is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        }
+
+        if (preg_match('/\W\D/', $value)) {
             $value = "\"$value\"";
         }
 
@@ -118,8 +122,8 @@ class Env
     /**
      * Copy the .env file to the given destination.
      *
-     * @param string $destination   Full path to copy the file to
-     * @param bool   $excludeValues Whether or not to include values
+     * @param string $destination Full path to copy the file to
+     * @param bool $excludeValues Whether or not to include values
      *
      * @return bool
      */
@@ -180,7 +184,7 @@ class Env
      *
      * @param string $old
      * @param string $new
-     * @param int    $append
+     * @param int $append
      *
      * @return \Sven\FlexEnv\Env
      */

--- a/src/Env.php
+++ b/src/Env.php
@@ -24,7 +24,7 @@ class Env
     /**
      * Instantiate the Env.
      *
-     * @param string $path
+     * @param  string  $path
      */
     public function __construct($path)
     {
@@ -39,8 +39,7 @@ class Env
     /**
      * Get an entry from the .env file by key.
      *
-     * @param string $key
-     *
+     * @param  string  $key
      * @return string
      */
     public function get($key)
@@ -57,10 +56,9 @@ class Env
     /**
      * Set the value of the given key to the value supplied.
      *
-     * @param string $key
-     * @param string|bool|int $value
-     * @param bool $linebreak
-     *
+     * @param  string  $key
+     * @param  string|bool|int  $value
+     * @param  bool  $linebreak
      * @return \Sven\FlexEnv\Env
      */
     public function set($key, $value, $linebreak = false)
@@ -89,8 +87,7 @@ class Env
     /**
      * Delete an entry from the .env file.
      *
-     * @param string $key
-     *
+     * @param  string  $key
      * @return \Sven\FlexEnv\Env
      */
     public function delete($key)
@@ -122,9 +119,8 @@ class Env
     /**
      * Copy the .env file to the given destination.
      *
-     * @param string $destination Full path to copy the file to
-     * @param bool $excludeValues Whether or not to include values
-     *
+     * @param  string  $destination  Full path to copy the file to
+     * @param  bool  $excludeValues  Whether or not to include values
      * @return bool
      */
     public function copy($destination, $excludeValues = false)
@@ -182,10 +178,9 @@ class Env
     /**
      * Replace a part of the .env file.
      *
-     * @param string $old
-     * @param string $new
-     * @param int $append
-     *
+     * @param  string  $old
+     * @param  string  $new
+     * @param  int  $append
      * @return \Sven\FlexEnv\Env
      */
     public function replaceInFile($old, $new, $append = 0)

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -49,6 +49,15 @@ class EnvTest extends EnvTestCase
     }
 
     /** @test */
+    public function it_can_set_boolean_values()
+    {
+        $result = $this->flex->set('BOOLEAN_VALUE', true)
+                            ->get('BOOLEAN_VALUE');
+
+        $this->assertEquals('true', $result);
+    }
+
+    /** @test */
     public function it_removes_an_entry()
     {
         $result1 = $this->flex->set('FOO_BAR', 'biz-baz')
@@ -91,7 +100,7 @@ class EnvTest extends EnvTestCase
                    ->set('VARIABLE', 'variable');
 
         $this->assertEquals(
-            ['HELLO_WORLD' => '"hello world"', 'TEST_VARIABLE' => '"test variable"', 'VARIABLE' => '"variable"'],
+            ['HELLO_WORLD' => '"hello world"', 'TEST_VARIABLE' => '"test variable"', 'VARIABLE' => 'variable'],
             $this->flex->all()
         );
     }
@@ -104,13 +113,13 @@ class EnvTest extends EnvTestCase
             ->set('MAIL_ENCRYPTION', 'tls');
 
         $this->assertEquals(
-            ['MAIL_USERNAME' => '"name@example.com"', 'MAIL_PASSWORD' => '"==hy6^gGbS+=="', 'MAIL_ENCRYPTION' => '"tls"'],
+            ['MAIL_USERNAME' => '"name@example.com"', 'MAIL_PASSWORD' => '"==hy6^gGbS+=="', 'MAIL_ENCRYPTION' => 'tls'],
             $this->flex->all()
         );
 
         $this->assertEquals('
 MAIL_USERNAME="name@example.com"
 MAIL_PASSWORD="==hy6^gGbS+=="
-MAIL_ENCRYPTION="tls"', file_get_contents(__DIR__.'/assets/.env'));
+MAIL_ENCRYPTION=tls', file_get_contents(__DIR__.'/assets/.env'));
     }
 }


### PR DESCRIPTION
Fixes #57.

This also no longer wraps values without special characters (regex `\W\D`) in quotes when setting it in the `.env` file.